### PR TITLE
Fix for trackData set to nil in stringOfXMLRequest

### DIFF
--- a/sdk/Anet SDK/PaymentType.m
+++ b/sdk/Anet SDK/PaymentType.m
@@ -61,7 +61,7 @@
     }
     else if (trackData.track1) {
         self.creditCard = nil;
-        self.trackData = nil;
+        self.bankAccount = nil;
         self.swiperData = nil;
     }
     else if (swiperData.deviceDescription) {


### PR DESCRIPTION
This is a fix for making payments using swiped card track data.
